### PR TITLE
Fix reference serialization inside classes

### DIFF
--- a/bitser.lua
+++ b/bitser.lua
@@ -151,14 +151,14 @@ local function write_number(value, _)
 	end
 end
 
-local function write_string(value, seen)
+local function write_string(value, _)
 	if #value < 32 then
 		--short string
 		Buffer_write_byte(192 + #value)
 	else
 		--long string
 		Buffer_write_byte(244)
-		write_number(#value, seen)
+		write_number(#value)
 	end
 	Buffer_write_string(value)
 end
@@ -173,14 +173,14 @@ end
 
 local function write_table(value, seen)
 	local classkey
-	local class = (class_name_registry[value.class] -- MiddleClass
+	local classname = (class_name_registry[value.class] -- MiddleClass
 		or class_name_registry[value.__baseclass] -- SECL
 		or class_name_registry[getmetatable(value)] -- hump.class
 		or class_name_registry[value.__class__]) -- Slither
-	if class then
-		classkey = classkey_registry[class]
+	if classname then
+		classkey = classkey_registry[classname]
 		Buffer_write_byte(242)
-		write_string(class)
+		serialize_value(classname, seen)
 	else
 		Buffer_write_byte(240)
 	end

--- a/spec/bitser_spec.lua
+++ b/spec/bitser_spec.lua
@@ -163,6 +163,37 @@ describe("bitser", function()
 		assert.is_true(class.isinstance(serdeser(bojack), Horse))
 		bitser.unregisterClass('Horse')
 	end)
+	it("serializes custom class instances", function()
+		local Horse_mt = bitser.registerClass('Horse', {__index = {}}, nil, setmetatable)
+		local function Horse(name)
+			local self = {}
+			self.name = name
+			self[1] = 'instance can be sequence'
+			return setmetatable(self, Horse_mt)
+		end
+		local bojack = Horse('Bojack Horseman')
+		test_serdeser(bojack)
+		assert.are.equal(getmetatable(serdeser(bojack)), Horse_mt)
+		bitser.unregisterClass('Horse')
+	end)
+	it("serializes classes that repeat keys", function()
+		local my_mt  = {"hi"}
+		local works  = { foo = 'a', bar = {baz = 'b'}, }
+		local broken = { foo = 'a', bar = {foo = 'b'}, }
+		local more_broken = {
+			foo = 'a',
+			baz = {foo = 'b', bar = 'c'},
+			quz = {bar = 'd', bam = 'e'}
+		}
+		setmetatable(works,  my_mt)
+		setmetatable(broken, my_mt)
+		setmetatable(more_broken, my_mt)
+		bitser.registerClass("Horse", my_mt, nil, setmetatable)
+		test_serdeser(works)
+		test_serdeser(broken)
+		test_serdeser(more_broken)
+		bitser.unregisterClass('Horse')
+	end)
 	it("serializes big data", function()
 		local text = "this is a lot of nonsense, please disregard, we need a lot of data to get past 4 KiB (114 characters should do it)"
 		local t = {}


### PR DESCRIPTION
Fixes #4.

My best explanation is that the deserializer treats the classname like a normal string, but since it was written using write_string() it didn't add itself to the seen table like every other string, causing a mismatch between the serializer-side seen table and the deserializer-side one.

I glanced and I saw resource serializing also uses write_string() but I don't really know what I'm doing so /shrug
